### PR TITLE
Check types as part of equality test

### DIFF
--- a/periodical.py
+++ b/periodical.py
@@ -399,6 +399,8 @@ class DatePeriod(object):
         return self.start > other.end
 
     def __eq__(self, other):
+        if type(self) is not type(other):
+            return False
         return self.start == other.start and self.end == other.end
 
 
@@ -628,6 +630,8 @@ class TimePeriod(object):
         return self.start >= other.end
 
     def __eq__(self, other):
+        if type(self) is not type(other):
+            return False
         return self.start == other.start and self.end == other.end
 
 

--- a/periodical.py
+++ b/periodical.py
@@ -399,7 +399,7 @@ class DatePeriod(object):
         return self.start > other.end
 
     def __eq__(self, other):
-        if type(self) is not type(other):
+        if not isinstance(other, DatePeriod):
             return False
         return self.start == other.start and self.end == other.end
 
@@ -630,7 +630,7 @@ class TimePeriod(object):
         return self.start >= other.end
 
     def __eq__(self, other):
-        if type(self) is not type(other):
+        if not isinstance(other, TimePeriod):
             return False
         return self.start == other.start and self.end == other.end
 

--- a/test.py
+++ b/test.py
@@ -253,6 +253,16 @@ class TestDatePeriods(unittest.TestCase):
         with self.assertRaises(ValueError):
             periodical.DatePeriod(date=date, span='blibble')
 
+    def test_invalid_date_period_comparison(self):
+        date = datetime.date(2000, 1, 1)
+        period = periodical.DatePeriod(date=date, span='day')
+        self.assertFalse(period == 5)
+
+    def test_invalid_time_period_comparison(self):
+        time = datetime.datetime(2000, 1, 1, 0, 0, 0)
+        period = periodical.TimePeriod(time=time, span='day')
+        self.assertFalse(period == 5)
+
     def test_unknown_representation(self):
         with self.assertRaises(ValueError):
             periodical.DatePeriod('199x')


### PR DESCRIPTION
This prevents errors if a `DatePeriod` or `TimePeriod` is compared against another type of object.

Comments on the approach taken very welcome. Could also duck type:

    return self.start == getattr(other, 'start', None) and self.end == getattr(other, 'end', None)

Not sure which is nicer..